### PR TITLE
⚡ Fix compatibility with Windows 

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -499,7 +499,7 @@ export default class flow {
       return
 
     var processChanges = () => {
-      utils.run('cp ' + newValue + ' ./assets/', false);
+      utils.copyFile(newValue, './assets/');
       newValue = newValue.split('/').pop();
       newValue = newValue.replaceAll('\\ ', ' ');
 
@@ -516,13 +516,9 @@ export default class flow {
     }
 
     if (!utils.directoryExists('./assets/')) {
-      utils.run('mkdir assets', false)
-        .then(() => {
-          processChanges()
-        });
-    } else {
-      processChanges()
+       utils.directoryCreate('assets');
     }
+    processChanges();
 
   }
 
@@ -849,7 +845,7 @@ export default class flow {
     if (utils.directoryExists('./content/' + newSection)) {
       console.log('Section already exists.');
     } else {
-      await utils.run('mkdir ./content/' + newSection, false);
+      utils.directoryCreate('./content/' + newSection);
       flow.showMain('Folder ' + newSection + ' created.')
     }
 
@@ -898,10 +894,9 @@ export default class flow {
           "#### This is a subsubsubheading\n" +
           "This is a paragraph with **bold** and *italic* text.\n" +
           "Check more at [Blowfish documentation](https://blowfish.page/)\n" +
-          await utils.run('mkdir ./content/' + response.option + '/' + articleid, false);
-        await utils.run('cp ' + utils.getDirname(import.meta.url) + '/../banner.png ./content/' + response.option + '/' + articleid + '/featured.png', false);
-        await utils.run('touch ./content/' + response.option + '/' + articleid + '/index.md', false);
-        await utils.run('echo \'' + content + '\' >> ./content/' + response.option + '/' + articleid + '/index.md', false);
+        utils.directoryCreate('./content/' + response.option + '/' + articleid);
+        utils.copyFile(utils.getDirname(import.meta.url) + '/../banner.png', './content/' + response.option + '/' + articleid + '/featured.png')
+        utils.writeContentToFile('./content/' + response.option + '/' + articleid + '/index.md', content);
         flow.showMain('Article ' + newArticle + ' created.')
       }
 

--- a/src/flow.js
+++ b/src/flow.js
@@ -515,9 +515,7 @@ export default class flow {
       utils.saveFileSync(file, toml.stringify(data));
     }
 
-    if (!utils.directoryExists('./assets/')) {
-       utils.directoryCreate('assets');
-    }
+    utils.directoryCreate('assets');
     processChanges();
 
   }

--- a/src/flow.js
+++ b/src/flow.js
@@ -489,19 +489,19 @@ export default class flow {
         type: 'input',
         name: 'value',
         default: currentValue,
-        message: 'Where image do you want to use? (full image path and the tool will copy it into the right folder)'
+        message: 'Where is the image you want to use? (full image path and the tool will copy it into the right folder)'
       }
     ]);
 
-    var newValue = response.value
+
+    var newValue = utils.normalizePath(response.value);
 
     if (newValue === currentValue)
       return
 
     var processChanges = () => {
-      utils.copyFile(newValue, './assets/');
-      newValue = newValue.split('/').pop();
-      newValue = newValue.replaceAll('\\ ', ' ');
+      utils.copyFileToFolder(newValue, 'assets');
+      newValue = utils.extractFileName(newValue);
 
       if (!parent) {
         data[variable] = newValue

--- a/src/utils.js
+++ b/src/utils.js
@@ -64,6 +64,28 @@ export default class utils {
       return false;
     }
   }
+  
+  static copyFile(src, dest) {
+    if (utils.fileExists(path)) {
+      return;
+    }
+   
+    try {
+      fs.copyFileSync(src, dest)
+    } catch (err) {
+      console.log(err)
+    }
+
+  }
+
+  static writeContentToFile(file, content)
+  {
+    fs.writeFile(file, content, (err) => {
+      if (err) {
+          console.error(err);
+      }
+    });
+  }
 
   static fileChange(path, strintoreplace, replacement) {
     var data = fs.readFileSync(path, 'utf8')

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,6 +56,38 @@ export default class utils {
     });
   }
 
+  static normalizePath(filePath) {
+    try {
+      
+      if (filePath.endsWith("'")) { 
+        if (filePath.startsWith("'")) {    // dragging to Git Bash in Windows quotes in single quotes if spaces in path
+          filePath = filePath.slice(1, -1);
+        } 
+        else if (filePath.startsWith("& '")) {  // dragging to Powershell also adds ampersand and space   
+          filePath = filePath.slice(3, -1);
+        } 
+      }
+      else if (filePath.startsWith("\"") && filePath.endsWith("\"")) {  // dragging to Command Prompt quotes with doublequotes if spaces   
+        filePath = filePath.slice(1, -1);
+      }
+
+      return path.normalize(filePath); 
+  
+    } catch (err) {
+      console.log(err);
+      return false;
+    }
+  }
+
+  static extractFileName(filePath) {
+    try {
+      return path.basename(filePath);
+    } catch (err) {
+      console.log(err)
+      return false;
+    }  
+  }
+
   static fileExists(path) {
     try {
       return fs.existsSync(path);
@@ -64,18 +96,19 @@ export default class utils {
       return false;
     }
   }
-  
-  static copyFile(src, dest) {
-    if (utils.fileExists(path)) {
-      return;
-    }
-   
-    try {
-      fs.copyFileSync(src, dest)
-    } catch (err) {
-      console.log(err)
-    }
 
+  static copyFile(srcFile, targetFile) {
+    try {
+      fs.copyFileSync(srcFile, targetFile);
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+
+  static copyFileToFolder(srcFile, destFolder) {
+    var targetFile = path.join(destFolder, path.basename(srcFile));
+    utils.copyFile(srcFile, targetFile);
   }
 
   static writeContentToFile(file, content)

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,7 +82,7 @@ export default class utils {
   {
     fs.writeFile(file, content, (err) => {
       if (err) {
-          console.error(err);
+        console.error(err);
       }
     });
   }


### PR DESCRIPTION
Windows can't find some of the `utils.run` commands or expects `\` instead `/` in paths. This means that Windows users can't create sections or new posts using the client. The problem also exists if running from Git Bash.  The solution is to replace the shell commands with `fs` calls that know how to handle Windows.

