### PR TITLE
fix #77, #78: Replace toml-patch to fix [params.author] output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,23 @@
       "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "chalk": "^5.3.0",
         "command-exists": "^1.2.9",
         "commander": "^11.1.0",
         "enquirer": "^2.4.1",
         "ora": "^8.0.1",
-        "tcp-port-used": "^1.0.2",
-        "toml-patch": "^0.2.3"
+        "tcp-port-used": "^1.0.2"
       },
       "bin": {
         "blowfish-tools": "cli.js"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -374,11 +380,6 @@
         "debug": "4.3.1",
         "is2": "^2.0.6"
       }
-    },
-    "node_modules/toml-patch": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/toml-patch/-/toml-patch-0.2.3.tgz",
-      "integrity": "sha512-SQI/j7f2S/iQZmoWBWNUMTfVmPbhP3+YCqxB/q8iOjdnXBk29HDARHzjCazmwftZaylYuMSrTTrvJiESVyzJzw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "homepage": "https://blowfish.page",
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "chalk": "^5.3.0",
     "command-exists": "^1.2.9",
     "commander": "^11.1.0",
     "enquirer": "^2.4.1",
     "ora": "^8.0.1",
-    "tcp-port-used": "^1.0.2",
-    "toml-patch": "^0.2.3"
+    "tcp-port-used": "^1.0.2"
   }
 }

--- a/src/flow.js
+++ b/src/flow.js
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import pkg from 'enquirer';
 const { prompt } = pkg;
-import toml from 'toml-patch';
+import toml from '@iarna/toml'
 import chalk from 'chalk';
 import tcpPortUsed from 'tcp-port-used';
 
@@ -451,15 +451,15 @@ export default class flow {
 
     const responseLinks = await prompt(linksQuestions);
 
-    if (!data.author)
-      data.author = {};
+    if (!data.params.author)
+      data.params.author = {};
 
-    data.author.links = [];
+    data.params.author.links = [];
 
     for (const [key, value] of Object.entries(responseLinks)) {
       var obj = {}
       obj[key] = value;
-      data.author.links.push(obj);
+      data.params.author.links.push(obj);
     }
 
     utils.saveFileSync(file, toml.stringify(data));


### PR DESCRIPTION
## Overview
Fixes [#77](https://github.com/nunocoracao/blowfish-tools/issues/77), [#78](https://github.com/nunocoracao/blowfish-tools/issues/78): Resolves site crash in "full configuration mode" when configuring author settings by ensuring consistent TOML output. Switches from `toml-patch` to `@iarna/toml` to address the issue.

## Issue Details
- **Problem**: In "full configuration mode", setting author's name followed by author's picture causes the site to crash with the error `unmarshal failed: toml: expected author to be a table, not a value` (see [#77](https://github.com/nunocoracao/blowfish-tools/issues/77), [#78](https://github.com/nunocoracao/blowfish-tools/issues/78)).
- **Repro Steps**:
  1. Configure author's name in "full configuration mode".
  2. Add author's picture or other author settings.
- **Cause**: The `languages.en.toml` file outputs a mix of `[params.author]` and `[params]author={}`, leading to invalid TOML.

## Changes
- Modified the TOML output to consistently use `[params.author]`.
- Replaced `toml-patch` with `@iarna/toml`, as `toml-patch` could not handle the required output format.
- `@iarna/toml` ( 
[npm](https://www.npmjs.com/package/@iarna/toml), [gitHub](https://github.com/iarna/iarna-toml)
)

## Formatting Notes
The fix resolves the crash, but the output `languages.en.toml` has minor formatting differences compared to the template:
- `["params.author"]` is quoted (e.g., `["params.author"]` instead of `[params.author]`).
- `author.links` is output as an Array of Tables, e.g.:
  ```toml
  [[params.author.links]]
  amazon = "XXX"

  [[params.author.links]]
  apple = "XXX"

These differences do not affect functionality, as the TOML is valid and works with Hugo. If aligning with the template is preferred, I'm happy to explore solutions in a follow-up PR. Please let me know your thoughts!

## Testing
Verified that the site builds successfully in "full configuration mode" with author settings (name, picture, headline, bio, links).


Happy to address the formatting differences in a separate PR if desired.
Thanks for reviewing!