### PR TITLE
Fix #90: Update parent to params.author in "Configure site author"

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -988,7 +988,7 @@ var options = [
 
       var tempList = []
       for (var i in configOptions) {
-        if (configOptions[i].parent === 'author' || configOptions[i].method === 'exit')
+        if (configOptions[i].parent === 'params.author' || configOptions[i].method === 'exit')
           tempList.push(configOptions[i])
       }
 


### PR DESCRIPTION
## Overview
Fixes #90: Updates the parent value from `author` to `params.author` in the menu list generation process from configOptions, executed when selecting " Configure site author".


## Issue Details
### Problem:
When the "Configure site author" command is executed in the CLI, no menu list is displayed in the terminal.

### Reproduction Steps:
1. Launch "blowfish-tools" (v1.10.0).
1. Select "Setup anew website with Blowfish" and enter an arbitrary site name.
1. Select "Configure site author".

### Cause:
The command generates a menu list from the `configOptions` object using data where parent is set to `author`. The list is empty because the correct parent key is `params.author`.

## Changes
Updated the parent value from `author` to `params.author`.

## Testing
Manually verified the "Configure site author" command in Blowfish-Tools (v1.10.0) to ensure the menu list displays correctly.
![confirm](https://github.com/user-attachments/assets/e0c92e0d-ff25-4569-bcb4-e967e8ce17c9)

<br>
Thanks for reviewing!