### PR TITLE
Fix #99: Correct typo 'Emable/Diable' to 'Enable/Disable'

### DIFF
--- a/configs/configOptions.json
+++ b/configs/configOptions.json
@@ -600,7 +600,7 @@
     "description": "Whether or not articles are grouped by year on term pages."
   },
   {
-    "text": "Emable/Diable card view for terms",
+    "text": "Enable/Disable card view for terms",
     "method": "configLoop",
     "file": "./config/_default/params.toml",
     "parent": "term",


### PR DESCRIPTION
## Summary
- Fixed typo in the term card view configuration option
- Changed "Emable/Diable" to "Enable/Disable" in `configs/configOptions.json`

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)