### PR TITLE
Fix #97: Handle trailing whitespace in directory input

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -101,12 +101,14 @@ export default class flow {
         return;
       }
 
+      response.directory = response.directory.trim();
+
       if (response.directory !== '.') {
         response.directory = './' + response.directory;
       }
 
     } else {
-      response.directory = directory;
+      response.directory = directory.trim();
     }
 
     const prespinner = ora('Checking folder').start();
@@ -181,12 +183,14 @@ export default class flow {
           message: 'Where do you want to generate your website (. for current folder)?'
         }]);
 
+      response.directory = response.directory.trim();
+
       if (response.directory !== '.') {
         response.directory = './' + response.directory;
       }
 
     } else {
-      response.directory = directory;
+      response.directory = directory.trim();
     }
 
     const prespinner = ora('Checking folder').start();


### PR DESCRIPTION
## Summary
- Trim directory input to prevent issues when users copy-paste paths with trailing spaces
- Applied fix to both `configureNew` and `copyTemplate` functions in `src/flow.js`

## Test Plan
1. Run `blowfish-tools`
2. Select "Setup a new website with Blowfish"
3. Enter a directory name with trailing space (e.g., "mysite ")
4. Verify the site is created correctly without errors

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)