### PR TITLE
Fix #83: Handle boolean false values correctly in config

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -427,20 +427,32 @@ export default class flow {
 
     var currentValue = null
 
-    if (parent && data[parent] && data[parent][variable]) {
+    if (parent && data[parent] && data[parent][variable] !== undefined) {
       currentValue = data[parent][variable]
-    } else if (!parent && data[variable]) {
+    } else if (!parent && data[variable] !== undefined) {
       currentValue = data[variable]
     }
 
+    // Determine if this is a boolean option based on current value or description
+    var isBoolean = typeof currentValue === 'boolean' ||
+      (description && (description.toLowerCase().includes('true or false') ||
+                       description.toLowerCase().includes('(true or false)') ||
+                       description.toLowerCase().includes('true/false')));
+
     console.log("Configuring:\n" + chalk.blue(variable) + (description ? ' - ' + description : ''))
+
+    // Convert boolean to string for display
+    var displayValue = currentValue;
+    if (typeof currentValue === 'boolean') {
+      displayValue = currentValue.toString();
+    }
 
     const response = await safePrompt([
       {
         type: 'input',
         name: 'value',
-        default: currentValue,
-        message: 'What is the new value?'
+        default: displayValue,
+        message: isBoolean ? 'What is the new value? (true/false)' : 'What is the new value?'
       }
     ]);
 


### PR DESCRIPTION
## Summary
- Fixed issue where `false` boolean values were shown as empty placeholders
- Check for `undefined` explicitly instead of using truthiness check
- Convert boolean values to strings for display
- Add `(true/false)` hint to prompt message for boolean options

## Changes
- `src/flow.js`: Modified `configLoop` function to properly handle boolean `false` values

## Before
When a config value was `false`, no placeholder was shown and users didn't know what values were valid.

## After
- `false` values are now correctly shown as the default
- Boolean options show `(true/false)` hint in the prompt

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)