### PR TITLE
Fix #100: Return to main menu when section already exists

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -848,7 +848,7 @@ export default class flow {
     var newSection = response.name;
 
     if (utils.directoryExists('./content/' + newSection)) {
-      console.log('Section already exists.');
+      flow.showMain('Section already exists.');
     } else {
       utils.directoryCreate('./content/' + newSection);
       flow.showMain('Folder ' + newSection + ' created.')


### PR DESCRIPTION
## Summary
- Fixed script hanging when trying to create a section that already exists
- Changed `console.log` to `flow.showMain` to return to main menu with the message

## Test Plan
1. Run `blowfish-tools`
2. Create a section (e.g., "posts")
3. Try to create the same section again
4. Verify the message appears and you're returned to the main menu

Fixes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)