### PR TITLE
Fix #101: Fix duplicate entries in Configure overall site menu

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -979,10 +979,8 @@ var options = [
       var tempList = []
       for (var i in configOptions) {
         if (configOptions[i].parent === null || configOptions[i].method === 'exit') {
-
+          tempList.push(configOptions[i])
         }
-
-        tempList.push(configOptions[i])
       }
 
       flow.enterConfigMode(tempList);


### PR DESCRIPTION
## Summary
- Fixed bug where "Configure overall site" menu showed duplicate entries
- The if-block was empty and items were pushed unconditionally after it
- Moved the push inside the if-block to properly filter items

## Root Cause
```javascript
// Before (broken)
if (condition) {
  // empty!
}
tempList.push(item) // Always executed

// After (fixed)
if (condition) {
  tempList.push(item) // Only when condition is true
}
```

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)