### PR TITLE
Fix #94: Treat directories with only hidden files as empty

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -141,7 +141,10 @@ export default class utils {
 
   static directoryIsEmpty(path) {
     try {
-      return fs.readdirSync(path).length === 0;
+      const files = fs.readdirSync(path);
+      // Treat directories with only hidden files (like .git, .gitignore) as empty
+      const nonHiddenFiles = files.filter(file => !file.startsWith('.'));
+      return nonHiddenFiles.length === 0;
     } catch (err) {
       return false;
     }


### PR DESCRIPTION
## Summary
- Modified `directoryIsEmpty` to ignore hidden files (starting with `.`)
- This allows creating a new Hugo site in a directory that only contains `.git` or `.gitignore`

## Use Case
A common workflow is to create a Git repository first, then initialize Hugo in it:
```bash
git init mysite
cd mysite
blowfish-tools new .
# Previously: "Directory already exists and is not empty."
# Now: Works correctly
```

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)