### PR TITLE
Fix #98: Fix menu deletion logic that caused duplicates

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -714,14 +714,10 @@ export default class flow {
 
           if (deleteHeaderResponse.value.length > 0) {
 
-            var newHeaderMenus = [];
-            for (var j in deleteHeaderResponse.value) {
-              for (var i in data.main) {
-                if (data.main[i].name != deleteHeaderResponse.value[j]) {
-                  newHeaderMenus.push(data.main[i]);
-                }
-              }
-            }
+            // Filter out menus that are in the delete list
+            var newHeaderMenus = data.main.filter(menu => {
+              return !deleteHeaderResponse.value.includes(menu.name);
+            });
             data.main = newHeaderMenus;
             if (data.main.length === 0) {
               data.main.push({ none: 'none' })
@@ -747,14 +743,10 @@ export default class flow {
 
           if (deleteFooterResponse.value.length > 0) {
 
-            var newFooterMenus = [];
-            for (var j in deleteFooterResponse.value) {
-              for (var i in data.footer) {
-                if (data.footer[i].name != deleteFooterResponse.value[j]) {
-                  newFooterMenus.push(data.footer[i]);
-                }
-              }
-            }
+            // Filter out menus that are in the delete list
+            var newFooterMenus = data.footer.filter(menu => {
+              return !deleteFooterResponse.value.includes(menu.name);
+            });
             data.footer = newFooterMenus;
             if (data.footer.length === 0) {
               data.footer.push({ none: 'none' })


### PR DESCRIPTION
## Summary
Fixed the menu deletion logic that was producing duplicate entries.

## Root Cause
The nested loop logic was inverted. For each item to delete, it would iterate through all menus and push non-matching items. This caused duplicates when deleting multiple items.

Example with menus A, B, C and selecting to delete A and B:
- First iteration (deleting A): pushes B, C
- Second iteration (deleting B): pushes A, C
- Result: [B, C, A, C] - duplicates!

## Solution
Changed to use `Array.filter()` to correctly exclude menus whose names are in the delete list.

```javascript
// Before (broken)
for (var j in deleteHeaderResponse.value) {
  for (var i in data.main) {
    if (data.main[i].name != deleteHeaderResponse.value[j]) {
      newHeaderMenus.push(data.main[i]);
    }
  }
}

// After (fixed)
var newHeaderMenus = data.main.filter(menu => {
  return !deleteHeaderResponse.value.includes(menu.name);
});
```

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)