### PR TITLE
Fix #79: Check git submodule exit code and fail gracefully

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -109,7 +109,12 @@ export default class flow {
     gitspinner.succeed('Git initialized');
 
     const blowfishspinner = ora('Installing Blowfish').start();
-    await utils.run(precommand + 'git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish', false);
+    const submoduleExitCode = await utils.run(precommand + 'git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish', false, true);
+    if (submoduleExitCode !== 0) {
+      blowfishspinner.fail('Failed to install Blowfish. Please check your network connection and try again.');
+      console.log('You can try manually running: git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish');
+      process.exit(1);
+    }
     blowfishspinner.succeed('Blowfish installed');
 
     const configblowfishspinner = ora('Configuring Blowfish').start();
@@ -194,7 +199,12 @@ export default class flow {
 
     const blowfishspinner = ora('Installing Blowfish').start();
     await utils.directoryDelete(response.directory + '/themes/blowfish')
-    await utils.run(precommand + 'git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish', false);
+    const submoduleExitCode = await utils.run(precommand + 'git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish', false, true);
+    if (submoduleExitCode !== 0) {
+      blowfishspinner.fail('Failed to install Blowfish. Please check your network connection and try again.');
+      console.log('You can try manually running: git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish');
+      process.exit(1);
+    }
     blowfishspinner.succeed('Blowfish installed');
 
     if (exitAfterRun)
@@ -221,7 +231,12 @@ export default class flow {
     gitspinner.succeed('Git initialized');
 
     const blowfishspinner = ora('Installing Blowfish').start();
-    await utils.run('git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish', false);
+    const submoduleExitCode = await utils.run('git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish', false, true);
+    if (submoduleExitCode !== 0) {
+      blowfishspinner.fail('Failed to install Blowfish. Please check your network connection and try again.');
+      console.log('You can try manually running: git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish');
+      process.exit(1);
+    }
     await utils.run('git submodule update --remote --merge', false);
     blowfishspinner.succeed('Blowfish installed');
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ export default class utils {
     return path.dirname(__filename);
   }
 
-  static run(cmd, pipe) {
+  static run(cmd, pipe, returnExitCode = false) {
     return new Promise((resolve, reject) => {
       const child = exec(cmd);
       if (pipe) {
@@ -21,7 +21,11 @@ export default class utils {
       }
       child.on('close', (code) => {
         //console.log(cmd + ` exited with code ${code}`);
-        resolve();
+        if (returnExitCode) {
+          resolve(code);
+        } else {
+          resolve();
+        }
       });
 
       process.on("exit", () => child.kill())


### PR DESCRIPTION
## Summary
Fixed the issue where project creation continues despite git submodule failure.

## Changes
- Added `returnExitCode` parameter to `utils.run()` function
- Check exit code after `git submodule add` commands
- If submodule fails, show error message with manual command suggestion

## Affected Functions
- `configureNew` - new site creation
- `copyTemplate` - template cloning
- `configureExisting` - installing on existing Hugo site

## Before
```
✔ Git initialized
✔ Blowfish installed  # Even though submodule failed!
✖ Error: ENOENT: no such file or directory...  # Crash later
```

## After
```
✔ Git initialized
✖ Failed to install Blowfish. Please check your network connection and try again.
You can try manually running: git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish
```

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)