### PR TITLE
Fix #81: Detect existing git repo in parent directories

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -128,9 +128,38 @@ export default class flow {
     hugospinner.succeed('Hugo site created');
 
     var precommand = 'cd ' + response.directory + ' && ';
-    const gitspinner = ora('Initializing Git').start();
-    await utils.run(precommand + 'git init', false)
-    gitspinner.succeed('Git initialized');
+
+    // Check if there's an existing git repo in parent directories
+    const existingGitRepo = utils.findGitRepoInParents(process.cwd());
+    let skipGitInit = false;
+
+    if (existingGitRepo) {
+      console.log(chalk.yellow('\nFound existing Git repository at: ' + existingGitRepo));
+      const gitChoice = await safePrompt({
+        type: 'select',
+        name: 'option',
+        message: 'How would you like to handle Git?',
+        choices: [
+          'Use existing repository (recommended for subdirectories)',
+          'Create new repository in ' + response.directory
+        ]
+      });
+
+      if (!gitChoice) {
+        flow.showMain();
+        return;
+      }
+
+      skipGitInit = gitChoice.option.includes('Use existing');
+    }
+
+    if (!skipGitInit) {
+      const gitspinner = ora('Initializing Git').start();
+      await utils.run(precommand + 'git init', false)
+      gitspinner.succeed('Git initialized');
+    } else {
+      console.log(chalk.green('✔ Using existing Git repository'));
+    }
 
     const blowfishspinner = ora('Installing Blowfish').start();
     const submoduleExitCode = await utils.run(precommand + 'git submodule add --depth 1 -b main https://github.com/nunocoracao/blowfish.git themes/blowfish', false, true);
@@ -219,9 +248,38 @@ export default class flow {
     hugospinner.succeed('Template cloned');
 
     var precommand = 'cd ' + response.directory + ' && ';
-    const gitspinner = ora('Initializing Git').start();
-    await utils.run(precommand + 'git init', false)
-    gitspinner.succeed('Git initialized');
+
+    // Check if there's an existing git repo in parent directories
+    const existingGitRepo = utils.findGitRepoInParents(process.cwd());
+    let skipGitInit = false;
+
+    if (existingGitRepo) {
+      console.log(chalk.yellow('\nFound existing Git repository at: ' + existingGitRepo));
+      const gitChoice = await safePrompt({
+        type: 'select',
+        name: 'option',
+        message: 'How would you like to handle Git?',
+        choices: [
+          'Use existing repository (recommended for subdirectories)',
+          'Create new repository in ' + response.directory
+        ]
+      });
+
+      if (!gitChoice) {
+        flow.showMain();
+        return;
+      }
+
+      skipGitInit = gitChoice.option.includes('Use existing');
+    }
+
+    if (!skipGitInit) {
+      const gitspinner = ora('Initializing Git').start();
+      await utils.run(precommand + 'git init', false)
+      gitspinner.succeed('Git initialized');
+    } else {
+      console.log(chalk.green('✔ Using existing Git repository'));
+    }
 
     const blowfishspinner = ora('Installing Blowfish').start();
     await utils.directoryDelete(response.directory + '/themes/blowfish')

--- a/src/utils.js
+++ b/src/utils.js
@@ -134,13 +134,28 @@ export default class utils {
     fs.writeFileSync(path, result, 'utf8')
   }
 
-  static directoryExists(path) {
+  static directoryExists(dirPath) {
     try {
-      return fs.existsSync(path);
+      return fs.existsSync(dirPath);
     } catch (err) {
       console.log(err)
       return false;
     }
+  }
+
+  static findGitRepoInParents(startPath) {
+    // Check if there's a .git folder in any parent directory
+    let currentPath = path.resolve(startPath);
+    const root = path.parse(currentPath).root;
+
+    while (currentPath !== root) {
+      const gitPath = path.join(currentPath, '.git');
+      if (fs.existsSync(gitPath)) {
+        return currentPath;
+      }
+      currentPath = path.dirname(currentPath);
+    }
+    return null;
   }
 
   static directoryIsEmpty(path) {


### PR DESCRIPTION
## Summary
- Added `findGitRepoInParents()` helper function to detect git repos in parent directories
- When creating a new site in a subdirectory of an existing git repo, the tool now offers a choice:
  - Use existing repository (recommended for subdirectories)
  - Create new repository in the subdirectory
- Applied to both `configureNew` and `copyTemplate` functions
- Prevents nested git repos and supports monorepo workflows

## Test Plan
1. Create a git repository: `mkdir test-parent && cd test-parent && git init`
2. Run `blowfish-tools` from within that directory
3. Select "Setup a new website with Blowfish"
4. Enter a subdirectory name like "my-site"
5. Verify the prompt appears asking how to handle Git
6. Select "Use existing repository" and verify no new git init is run

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)