### PR TITLE
Fix #84: Skip config save when value unchanged

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -462,11 +462,18 @@ export default class flow {
     }
 
     var newValue = response.value
-    if (newValue === 'true')
-      newValue = true
-    if (newValue === 'false')
-      newValue = false
 
+    // Convert string to appropriate type based on content or original value type
+    if (newValue === 'true') {
+      newValue = true;
+    } else if (newValue === 'false') {
+      newValue = false;
+    } else if (typeof currentValue === 'number' && !isNaN(Number(newValue))) {
+      // Convert to number if current value is a number and input is numeric
+      newValue = Number(newValue);
+    }
+
+    // Skip save if value hasn't changed
     if (newValue === currentValue)
       return
 


### PR DESCRIPTION
## Summary
- Fixed type comparison issue in `configLoop` function
- When `currentValue` is a number (e.g., `1313`) and user input is a string (e.g., `"1313"`), the comparison was failing
- Now converts string input to the appropriate number type when the original value is numeric
- This prevents unnecessary file writes when users accept the default value

## The Problem
```javascript
currentValue = 1313  // number from TOML
response.value = "1313"  // string from prompt
"1313" === 1313  // false - file was saved unnecessarily
```

## The Fix
Added number conversion when the original value is numeric:
```javascript
if (typeof currentValue === 'number' && !isNaN(Number(newValue))) {
  newValue = Number(newValue);
}
```

## Test Plan
1. Run `blowfish-tools`
2. Select "Configure overall site"
3. Choose a numeric option (like port)
4. Press Enter to accept the default value
5. Verify the config file is NOT modified (check git status)

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)