### PR TITLE
Fix #123: Create _index.md when generating new sections

### DIFF
--- a/src/flow.js
+++ b/src/flow.js
@@ -1012,7 +1012,13 @@ export default class flow {
       flow.showMain('Section already exists.');
     } else {
       utils.directoryCreate('./content/' + newSection);
-      flow.showMain('Folder ' + newSection + ' created.')
+      // Create _index.md so Hugo recognizes this as a section with its own page
+      var sectionTitle = newSection.charAt(0).toUpperCase() + newSection.slice(1);
+      var indexContent = "---\n" +
+        "title: \"" + sectionTitle + "\"\n" +
+        "---\n";
+      utils.writeContentToFile('./content/' + newSection + '/_index.md', indexContent);
+      flow.showMain('Section ' + newSection + ' created.')
     }
 
   }


### PR DESCRIPTION
## Summary
- Fixed article page generation bug by creating `_index.md` when generating new sections
- Hugo requires `_index.md` to recognize a directory as a section with its own page
- Without this file, both section URLs (`/baking/`) and article URLs (`/baking/cake-recipe/`) fail to render

Closes #123

## Test plan
- [ ] Create a new Hugo project with blowfish-tools
- [ ] Generate a new section (e.g., "baking")
- [ ] Verify `_index.md` exists in `content/baking/`
- [ ] Generate a new article in the section
- [ ] Run Hugo local server
- [ ] Verify section page loads at `/baking/`
- [ ] Verify article page loads at `/baking/cake-recipe/`
- [ ] Verify articles appear in recent articles list

🤖 Generated with [Claude Code](https://claude.com/claude-code)