### PR TITLE
Add StoryGraph link option for author profiles

### DIFF
--- a/configs/icons.json
+++ b/configs/icons.json
@@ -64,6 +64,7 @@
     "stack-overflow",
     "star",
     "steam",
+    "storygraph",
     "stripe",
     "substack",
     "sun",


### PR DESCRIPTION
## Summary
- Adds StoryGraph to the supported icons list for author profile links
- StoryGraph is a book tracking social platform similar to Goodreads
- Allows users to configure their StoryGraph profile link alongside other social links

## Test plan
- [x] Verify JSON remains valid after adding storygraph entry
- [ ] Run blowfish-tools and verify storygraph appears in the author links selection
- [ ] Configure a storygraph link and verify it gets saved to the TOML config

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)