### PR TITLE
Fix #120: Remove duplicate entry in article configuration

### DIFF
--- a/configs/configOptions.json
+++ b/configs/configOptions.json
@@ -328,7 +328,7 @@
     "description": "Whether or not breadcrumbs are displayed in the article header."
   },
   {
-    "text": "Show/Hide breadcrumbs in articles",
+    "text": "Show/Hide draft label in articles",
     "method": "configLoop",
     "file": "./config/_default/params.toml",
     "parent": "article",


### PR DESCRIPTION
## Summary
- Fixed duplicate "Show/Hide breadcrumbs in articles" entry in the article configuration menu
- The `showDraftLabel` config entry incorrectly had the same display text as `showBreadcrumbs`
- Updated text to "Show/Hide draft label in articles" to correctly match its function

## Test plan
- [x] Verify no duplicate entries exist in `configs/configOptions.json`
- [x] Confirm JSON file is valid
- [ ] Open the article configuration menu and verify all options appear exactly once

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)